### PR TITLE
Update HandledScreenMixin.java

### DIFF
--- a/src/main/java/com/loucaskreger/searchablecontainers/mixin/HandledScreenMixin.java
+++ b/src/main/java/com/loucaskreger/searchablecontainers/mixin/HandledScreenMixin.java
@@ -128,11 +128,11 @@ public class HandledScreenMixin extends Screen {
     @Inject(at = @At(value = "HEAD"), method = "keyPressed", cancellable = true)
     private void onKeyPressed(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> ci) {
         if (this.textField != null) {
-            if (keyCode == GLFW_KEY_E && this.textField.isFocused()) {
+            if (MinecraftClient.getInstance().options.keyInventory.matchesKey(keyCode, scanCode) && this.textField.isFocused()) {
                 ci.cancel();
             }
 
-            if (keyCode == SearchableContainers.HIDE_KEY.getDefaultKey().getCode() && modifiers == 2 && !this.textField.isFocused()) {
+            if (SearchableContainers.HIDE_KEY.matchesKey(keyCode, scanCode) && modifiers == 2 && !this.textField.isFocused()) {
                 SmartTextField.isVisible = !SmartTextField.isVisible;
                 this.textField.setVisible(SmartTextField.isVisible);
             }


### PR DESCRIPTION
Please instead of checking `keyCode == GLFW_KEY_E` (which might have been changed by the user in his keyBinding settings, you should definitely use `MinecraftClient.getInstance().options.keyInventory.matchesKey(keyCode, scanCode)`.

For `keyCode == SearchableContainers.HIDE_KEY.getDefaultKey().getCode()` same thing. If you getDefaultKey(), whats even the point of creating a custom keybinding? getDefaultKey() will always return `H` even if you change it. Please use `SearchableContainers.HIDE_KEY.matchesKey(keyCode, scanCode)` instead.